### PR TITLE
Fix dashboard knob display issue

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -3,6 +3,8 @@ import { ref } from 'vue';
 import { Head as InertiaHead } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import Knob from 'primevue/knob';
+import Card from 'primevue/card';
+import Button from 'primevue/button';
 const breadcrumbs = [{ label: 'Dashboard' }];
 const value = ref(0);
 </script>


### PR DESCRIPTION
Add missing PrimeVue `Card` and `Button` imports to `Dashboard.vue`.

The Knob component was not displaying because its parent `Card` and control `Button` components were not imported, preventing the template from rendering correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6d97b5e-e80f-464f-acda-4942b21e269a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6d97b5e-e80f-464f-acda-4942b21e269a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

