### PR TITLE
Investigate knob visibility issue

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -15,7 +15,6 @@ const value = ref(0);
     <AppLayout :breadcrumbs>        
         <Card>
             <template #content>
-                <template>
                     <div class="card flex flex-col items-center gap-2">
                         <Knob v-model="value" :size="150" readonly />
                         <div class="flex gap-2">
@@ -23,7 +22,6 @@ const value = ref(0);
                             <Button icon="pi pi-minus" @click="value--" :disabled="value <= 0" />
                         </div>
                     </div>
-                </template>
             </template>
         </Card>
     </AppLayout>


### PR DESCRIPTION
Remove unnecessary nested `<template>` block to allow `Knob` and other components to render inside `Card`'s content slot.

A redundant `<template>` wrapper inside the `Card`'s `#content` slot prevented its children, including the `Knob` and control `Button` components, from being rendered by Vue. Removing this wrapper ensures the components display correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8b47f63-aafc-4787-9ae5-7697f7169c7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8b47f63-aafc-4787-9ae5-7697f7169c7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

